### PR TITLE
Support `batchbald` (BatchBALD) as a certainty metric

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@ RUN apt-get update && \
 
 COPY . /opt/scw
 WORKDIR /opt/scw
-RUN python -m pip install -e .[tensorflow] --find-links https://girder.github.io/large_image_wheels
+RUN python -m pip install -e .[tensorflow,torch] --find-links https://girder.github.io/large_image_wheels --extra-index-url https://download.pytorch.org/whl/cu117
 
 # Use a newer histomicstk
 # Not needed if we install histomicstk from pypi
 # RUN apt-get update && apt-get install -y git build-essential && \
 #     git clone --depth=1 --single-branch -b master https://github.com/DigitalSlideArchive/HistomicsTK.git && \
 #     cd HistomicsTK && \
-#     pip install .[tensorflow]
+#     pip install .[tensorflow,torch]
 
 WORKDIR /opt/scw/superpixel_classification
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "SuperpixelClassification"
 dynamic = ["version"]
 readme = "README.rst"
 classifiers = ["License :: OSI Approved :: Apache Software License"]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = [
     "girder-client",
     "girder-slicer-cli-web",
@@ -26,4 +26,8 @@ dependencies = [
 tensorflow = [
     "tensorflow>=2.6,<3.0",
     "keras",
+]
+torch = [
+    "torch==1.13.1+cu117",
+    "batchbald_redux",
 ]

--- a/superpixel_classification/SuperpixelClassification/SuperpixelClassification.xml
+++ b/superpixel_classification/SuperpixelClassification/SuperpixelClassification.xml
@@ -154,6 +154,7 @@
       <element>confidence</element>
       <element>margin</element>
       <element>negative_entropy</element>
+      <element>batchbald</element>
     </string-enumeration>
   </parameters>
   <parameters advanced="true">

--- a/superpixel_classification/SuperpixelClassification/SuperpixelClassificationBase.py
+++ b/superpixel_classification/SuperpixelClassification/SuperpixelClassificationBase.py
@@ -14,9 +14,8 @@ import time
 import girder_client
 import h5py
 import numpy as np
-from tenacity import Retrying, stop_after_attempt
-
 from progress_helper import ProgressHelper
+from tenacity import Retrying, stop_after_attempt
 
 
 def summary_repr(contents, collapseSequences=False):
@@ -46,63 +45,63 @@ def summary_repr(contents, collapseSequences=False):
     if isinstance(contents, list):
         if collapseSequences and len(contents) > 1:
             return (
-                '['
-                + summary_repr(contents[0], collapseSequences)
-                + f", 'and {len(contents) - 1} more'"
-                + ']'
+                '[' +
+                summary_repr(contents[0], collapseSequences) +
+                f", 'and {len(contents) - 1} more'" +
+                ']'
             )
         return (
-            '['
-            + ', '.join([summary_repr(elem, collapseSequences) for elem in contents])
-            + ']'
+            '[' +
+            ', '.join([summary_repr(elem, collapseSequences) for elem in contents]) +
+            ']'
         )
     if isinstance(contents, tuple):
         if collapseSequences and len(contents) > 1:
             return (
-                '('
-                + summary_repr(contents[0], collapseSequences)
-                + f", 'and {len(contents) - 1} more'"
-                + ',)'
+                '(' +
+                summary_repr(contents[0], collapseSequences) +
+                f", 'and {len(contents) - 1} more'" +
+                ',)'
             )
         return (
-            '('
-            + ', '.join([summary_repr(elem, collapseSequences) for elem in contents])
-            + ',)'
+            '(' +
+            ', '.join([summary_repr(elem, collapseSequences) for elem in contents]) +
+            ',)'
         )
     if isinstance(contents, dict):
         return (
-            '{'
-            + ', '.join(
+            '{' +
+            ', '.join(
                 [
-                    summary_repr(key, collapseSequences)
-                    + ': '
-                    + summary_repr(value, collapseSequences)
+                    summary_repr(key, collapseSequences) +
+                    ': ' +
+                    summary_repr(value, collapseSequences)
                     for key, value in contents.items()
                 ],
-            )
-            + '}'
+            ) +
+            '}'
         )
     if isinstance(contents, set):
         if collapseSequences and len(contents) > 1:
             return (
-                '{'
-                + summary_repr(next(iter(contents)), collapseSequences)
-                + f", 'and {len(contents) - 1} more'"
-                + '}'
+                '{' +
+                summary_repr(next(iter(contents)), collapseSequences) +
+                f", 'and {len(contents) - 1} more'" +
+                '}'
             )
         return (
-            '{'
-            + ', '.join([summary_repr(elem, collapseSequences) for elem in contents])
-            + '}'
+            '{' +
+            ', '.join([summary_repr(elem, collapseSequences) for elem in contents]) +
+            '}'
         )
     if isinstance(contents, np.ndarray):
         return (
-            repr(type(contents))
-            + '(shape='
-            + repr(contents.shape)
-            + ', dtype=np.'
-            + repr(contents.dtype)
-            + ')'
+            repr(type(contents)) +
+            '(shape=' +
+            repr(contents.shape) +
+            ', dtype=np.' +
+            repr(contents.dtype) +
+            ')'
         )
     return repr(type(contents))
 
@@ -197,7 +196,8 @@ class SuperpixelClassificationBase:
 
     def createSuperpixelsForItem(self, gc, annotationName, item, radius, magnification,
                                  annotationFolderId, userId, prog):
-        from histomicstk.cli.SuperpixelSegmentation import SuperpixelSegmentation
+        from histomicstk.cli.SuperpixelSegmentation import \
+            SuperpixelSegmentation
 
         def progCallback(step, count, total):
             if step == 'tiles':

--- a/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTensorflow.py
+++ b/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTensorflow.py
@@ -1,7 +1,6 @@
 import os
 
 import tensorflow as tf
-
 from SuperpixelClassificationBase import SuperpixelClassificationBase
 
 

--- a/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTensorflow.py
+++ b/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTensorflow.py
@@ -1,7 +1,7 @@
 import os
 
-import numpy as np
 import tensorflow as tf
+
 from SuperpixelClassificationBase import SuperpixelClassificationBase
 
 
@@ -76,15 +76,16 @@ class SuperpixelClassificationTensorflow(SuperpixelClassificationBase):
         return history, modelPath
 
     def predictLabelsForItemDetails(self, batchSize, ds, item, model, prog):
+        # TODO: !!! Should we create a tf.data.Dataset.from_tensor_slices from ds, then
+        # invoke .batch(bathSize), and then give to model.predict()?  Otherwise,
+        # batchSize seems to be ignored.
         predictions = model.predict(
             ds, callbacks=[_LogTensorflowProgress(
                 prog, (ds.shape[0] + batchSize - 1) // batchSize, 0.05, 0.35, item)])
         prog.item_progress(item, 0.4)
-        # scale to units
-        cats = [np.argmax(r) for r in predictions]
         # softmax to scale to 0 to 1
         catWeights = tf.nn.softmax(predictions)
-        return cats, catWeights, predictions
+        return catWeights, predictions
 
     def loadModel(self, modelPath):
         return tf.keras.models.load_model(modelPath)

--- a/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTorch.py
+++ b/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTorch.py
@@ -4,7 +4,6 @@ import batchbald_redux as bbald
 import batchbald_redux.consistent_mc_dropout
 import numpy as np
 import torch
-
 from SuperpixelClassificationBase import SuperpixelClassificationBase
 
 

--- a/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTorch.py
+++ b/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTorch.py
@@ -1,19 +1,15 @@
-import logging
-import math
 import os
 
 import batchbald_redux as bbald
 import batchbald_redux.consistent_mc_dropout
 import numpy as np
 import torch
-from SuperpixelClassificationBase import (SuperpixelClassificationBase,
-                                          summary_repr)
 
-logger = logging.getLogger(__name__)
+from SuperpixelClassificationBase import SuperpixelClassificationBase
 
 
 class _LogTorchProgress:
-    def __init__(self, prog, total, start=0, width=1, item=None):
+    def __init__(self, prog, total, start=0, width=1, item=None) -> None:
         """Pass a progress class and the total number of total"""
         self.prog = prog
         self.total = total
@@ -21,39 +17,39 @@ class _LogTorchProgress:
         self.width = width
         self.item = item
 
-    def on_epoch_begin(self, epoch, logs=None):
+    def on_epoch_begin(self, epoch, logs=None) -> None:
         pass
 
-    def on_epoch_end(self, epoch, logs=None):
+    def on_epoch_end(self, epoch, logs=None) -> None:
         val = ((epoch + 1) / self.total) * self.width + self.start
         if self.item is None:
             self.prog.progress(val)
         else:
             self.prog.item_progress(self.item, val)
-        # Save logs information to report later!!!
+        # TODO: Save logs information to report later
 
-    def on_train_begin(self, logs=None):
+    def on_train_begin(self, logs=None) -> None:
         pass
 
-    def on_train_end(self, logs=None):
+    def on_train_end(self, logs=None) -> None:
         pass
 
-    def on_train_batch_begin(self, batch, logs=None):
+    def on_train_batch_begin(self, batch, logs=None) -> None:
         pass
 
-    def on_train_batch_end(self, batch, logs=None):
+    def on_train_batch_end(self, batch, logs=None) -> None:
         pass
 
-    def on_predict_begin(self, logs=None):
+    def on_predict_begin(self, logs=None) -> None:
         pass
 
-    def on_predict_end(self, logs=None):
+    def on_predict_end(self, logs=None) -> None:
         pass
 
-    def on_predict_batch_begin(self, batch, logs=None):
+    def on_predict_batch_begin(self, batch, logs=None) -> None:
         pass
 
-    def on_predict_batch_end(self, batch, logs=None):
+    def on_predict_batch_end(self, batch, logs=None) -> None:
         val = ((batch + 1) / self.total) * self.width + self.start
         if self.item is None:
             self.prog.progress(val)
@@ -61,9 +57,15 @@ class _LogTorchProgress:
             self.prog.item_progress(self.item, val)
 
 
-class _TorchModel(torch.nn.Module):
-    def __init__(self, num_classes: int):
-        super(_TorchModel, self).__init__()
+class _BayesianTorchModel(bbald.consistent_mc_dropout.BayesianModule):
+    def __init__(self, num_classes: int) -> None:
+        self.device = torch.device(
+            'cuda'
+            if torch.cuda.is_available() and torch.cuda.device_count() > 0
+            else 'cpu',
+        )
+        super(_BayesianTorchModel, self).__init__()
+        self.to(self.device)
 
         self.conv1: torch.Module = torch.nn.Conv2d(3, 16, kernel_size=3, padding=1)
         self.conv1_drop: torch.Module = bbald.consistent_mc_dropout.ConsistentMCDropout2d()
@@ -71,11 +73,14 @@ class _TorchModel(torch.nn.Module):
         self.conv2_drop: torch.Module = bbald.consistent_mc_dropout.ConsistentMCDropout2d()
         self.conv3: torch.Module = torch.nn.Conv2d(32, 64, kernel_size=3, padding=1)
         self.conv3_drop: torch.Module = bbald.consistent_mc_dropout.ConsistentMCDropout2d()
-        self.fc1: torch.Module = torch.nn.Linear(1024, 128)
+        self.fc1: torch.Module = torch.nn.Linear(9216, 128)
         self.fc1_drop: torch.Module = bbald.consistent_mc_dropout.ConsistentMCDropout()
         self.fc2: torch.Module = torch.nn.Linear(128, num_classes)
 
-    def forward(self, input: torch.Tensor):
+        self.num_classes: int = num_classes
+        self.bayesian_samples: int = 12
+
+    def mc_forward_impl(self, input: torch.Tensor) -> torch.Tensor:
         input = torch.mul(input, 1.0 / 255)
 
         input = self.conv1(input)
@@ -93,30 +98,18 @@ class _TorchModel(torch.nn.Module):
         input = torch.nn.functional.max_pool2d(input, 2)
         input = torch.nn.functional.relu(input)
 
-        input = input.view(-1, 1024)
+        input = input.view(-1, 9216)
 
         input = self.fc1(input)
         input = self.fc1_drop(input)
         input = torch.nn.functional.relu(input)
 
         input = self.fc2(input)
+
         # To remain consistent with the Tensorflow implementation, we will not include
         # `input = torch.nn.functional.log_softmax(input, dim=1)` at this point.
 
         return input
-
-
-class _ZipDataset(torch.utils.data.Dataset):
-    def __init__(self, train_features, train_labels) -> None:
-        torch.utils.data.Dataset.__init__(self)
-        self.train_features = torch.from_numpy(train_features)
-        self.train_labels = torch.from_numpy(train_labels)
-
-    def __len__(self) -> int:
-        return self.train_labels.shape[0]
-
-    def __getitem__(self, index: int):
-        return self.train_features[index, :], self.train_labels[index]
 
 
 class SuperpixelClassificationTorch(SuperpixelClassificationBase):
@@ -127,30 +120,32 @@ class SuperpixelClassificationTorch(SuperpixelClassificationBase):
         # Split data into training and validation.  H5py requires that indices be
         # sorted.
         train_size = int(count * trainingSplit)
-        shuffle = np.random.permutation(count)  # add seed=123 ?
+        shuffle = np.random.permutation(count)  # TODO: add seed=123?
         train_indices = np.sort(shuffle[0:train_size])
         val_indices = np.sort(shuffle[train_size:count])
-        train_ds = _ZipDataset(record['ds'][train_indices].transpose((0, 3, 2, 1)),
-                               record['labelds'][train_indices])
-        val_ds = _ZipDataset(record['ds'][val_indices].transpose((0, 3, 2, 1)),
-                             record['labelds'][val_indices])
+        train_arg1 = torch.from_numpy(record['ds'][train_indices].transpose((0, 3, 2, 1)))
+        train_arg2 = torch.from_numpy(record['labelds'][train_indices])
+        val_arg1 = torch.from_numpy(record['ds'][val_indices].transpose((0, 3, 2, 1)))
+        val_arg2 = torch.from_numpy(record['labelds'][val_indices])
+        train_ds = torch.utils.data.TensorDataset(train_arg1, train_arg2)
+        val_ds = torch.utils.data.TensorDataset(val_arg1, val_arg2)
         train_dl = torch.utils.data.DataLoader(train_ds, batch_size=batchSize)
         val_dl = torch.utils.data.DataLoader(val_ds, batch_size=batchSize)
-        print(batchSize, train_dl, val_dl)
         prog.progress(0.2)
 
         # make model
         num_classes = len(record['labels'])
-        model: torch.nn.Module = _TorchModel(num_classes)
+        model: torch.nn.Module = _BayesianTorchModel(num_classes)
         prog.message('Training model')
         prog.progress(0)
 
-        history = self.fitModel(model, train_dl, val_dl, epochs,
-                                callbacks=[_LogTorchProgress(prog, epochs)])
+        history = self.fitModel(
+            model, train_dl, val_dl, epochs, callbacks=[_LogTorchProgress(prog, epochs)],
+        )
 
         prog.message('Saving model')
         prog.progress(0)
-        modelPath = os.path.join(tempdir, '%s Model Epoch %d.h5' % (
+        modelPath = os.path.join(tempdir, '%s Model Epoch %d.pth' % (
             annotationName, self.getCurrentEpoch(itemsAndAnnot)))
         self.saveModel(model, modelPath)
         return history, modelPath
@@ -161,7 +156,9 @@ class SuperpixelClassificationTorch(SuperpixelClassificationBase):
         criterion = torch.nn.functional.nll_loss
         optimizer = torch.optim.Adam(model.parameters())
 
-        num_validation_samples: int = 1  # Is this right?
+        # TODO: What are good values for num_samples here?!!!  Eg., simply 1?
+        num_training_samples: int = 12
+        num_validation_samples: int = 12
         # Loop over the dataset multiple times
         for epoch in range(epochs):
             for cb in callbacks:
@@ -169,31 +166,36 @@ class SuperpixelClassificationTorch(SuperpixelClassificationBase):
             train_loss: float = 0.0
             train_size: int = 0
             train_correct: float = 0.0
-            for i, data in enumerate(train_dl):
+            for batch, data in enumerate(train_dl):
                 for cb in callbacks:
-                    cb.on_train_batch_begin(i, logs=dict())
+                    cb.on_train_batch_begin(batch, logs=dict())
                 inputs, labels = data
-                info = f'inputs = {summary_repr(inputs)}'
-                logger.info(info)
-                info = f'labels = {summary_repr(labels)}'
-                logger.info(info)
                 # zero the parameter gradients
                 optimizer.zero_grad()
 
                 # forward + backward + optimize
-                outputs = model(inputs)
-                # Apparently our criterion, nll_loss, requires that we squeeze our
-                # `outputs` value here
-                criterion_loss = criterion(outputs.squeeze(1), labels)
+                outputs = model(inputs, num_training_samples)
+                outputs = torch.nn.functional.log_softmax(outputs, dim=-1)
+                # outputs.shape == (batch_size, num_training_samples, num_classes).
+                # labels.shape  == (batch_size).
+                # Broadcast labels to the same shape as outputs.shape[0:2]
+                labels = labels[:, None].expand(*outputs.shape[0:2])
+                criterion_loss = criterion(
+                    outputs.reshape(-1, outputs.shape[-1]),
+                    labels.reshape(-1),
+                )
                 criterion_loss.backward()
                 optimizer.step()
                 new_size: int = inputs.size(0)
+                # print(f'new_size[{epoch}, {batch}] = {new_size}')
                 train_size += new_size
-                new_loss: float = criterion_loss.item() * inputs.size(0)
+                new_loss: float = criterion_loss.item() * new_size
+                # print(f'new_loss[{epoch}, {batch}] = {new_loss}')
                 train_loss += new_loss
                 new_correct_t: torch.Tensor
-                new_correct_t = (torch.argmax(outputs, dim=1) == labels).float().sum()
+                new_correct_t = (torch.argmax(outputs, dim=-1) == labels).float().sum()
                 new_correct: float = new_correct_t.detach().cpu().numpy()
+                # print(f'new_correct[{epoch}, {batch}] = {new_correct}')
                 train_correct += new_correct
                 loss: float = new_loss / new_size
                 accuracy: float = new_correct / new_size
@@ -201,7 +203,7 @@ class SuperpixelClassificationTorch(SuperpixelClassificationBase):
                     accuracy = accuracy[()]
                 logs = {'loss': loss, 'accuracy': accuracy}
                 for cb in callbacks:
-                    cb.on_train_batch_end(i, logs)
+                    cb.on_train_batch_end(batch, logs)
             loss = train_loss / train_size
             accuracy = train_correct / train_size
             if not isinstance(accuracy, (int, float, np.float32, np.float64)):
@@ -215,17 +217,22 @@ class SuperpixelClassificationTorch(SuperpixelClassificationBase):
                 model.eval()  # Tell torch that we will be doing predictions
                 for data in val_dl:
                     inputs, labels = data
-                    outputs = model(inputs)
-                    # Collapse multiple predictions into single one
-                    outputs = torch.logsumexp(outputs, dim=1) - math.log(num_validation_samples)
-                    # Apparently our criterion, nll_loss, requires that we squeeze
-                    # our `labels` value here
-                    criterion_loss = criterion(outputs, labels.squeeze(1), reduction='sum')
+                    outputs = model(inputs, num_validation_samples)
+                    outputs = torch.nn.functional.log_softmax(outputs, dim=-1)
+                    # outputs.shape == (batch_size, num_training_samples, num_classes).
+                    # labels.shape  == (batch_size).
+                    # Broadcast labels to the same shape as outputs.shape[0:2]
+                    labels = labels[:, None].expand(*outputs.shape[0:2])
+                    criterion_loss = criterion(
+                        outputs.reshape(-1, outputs.shape[-1]),
+                        labels.reshape(-1),
+                        reduction='sum',
+                    )
                     new_size = inputs.size(0)
                     validation_size += new_size
                     new_loss = criterion_loss.item() * inputs.size(0)
                     validation_loss += new_loss
-                    new_correct_t = (torch.argmax(outputs, dim=1) == labels).float().sum()
+                    new_correct_t = (torch.argmax(outputs, dim=-1) == labels).float().sum()
                     new_correct = new_correct_t.detach().cpu().numpy()
                     validation_correct += new_correct
                 val_loss: float = validation_loss / validation_size
@@ -237,26 +244,62 @@ class SuperpixelClassificationTorch(SuperpixelClassificationBase):
 
         for cb in callbacks:
             cb.on_train_end(logs)  # `logs` is from the last epoch
-        # Needs a meaningful return value in lieu of tensorflow.History object!!!
-        return None
+        history = []  # TODO: Perhaps return something meaningful?
+        return history
 
-    def predictLabelsForItemDetails(self, batchSize, ds, item, model, prog):
+    def predictLabelsForItemDetails(self, batchSize, ds_h5, item, model, prog):
+        num_superpixels: int = ds_h5.shape[0]
+        # print(f'{num_superpixels = }')
+        bayesian_samples: int = model.bayesian_samples
+        # print(f'{bayesian_samples = }')
+        num_classes: int = model.num_classes
+        # print(f'{num_classes = }')
+
+        # TODO: Stop overriding batchSize!!! We are ignoring the supplied value of
+        # batchSize because that is what SuperpixelClassificationTensorflow is doing.
+        # Instead we should have the calling routine pass in a reasonable value, which
+        # might be distinct from the batch size used during training.
+        batchSize = 1 + (num_superpixels - 1) // bayesian_samples
+        # batchSize = num_superpixels  # This can be too many
+
         callbacks = [_LogTorchProgress(
-            prog, (ds.shape[0] + batchSize - 1) // batchSize, 0.05, 0.35, item)]
+            prog, 1 + (num_superpixels - 1) // batchSize, 0.05, 0.35, item)]
+        logs = dict(
+            num_superpixels=num_superpixels,
+            bayesian_samples=bayesian_samples,
+            num_classes=num_classes,
+        )
         for cb in callbacks:
-            cb.on_predict_begin(logs=dict())
+            cb.on_predict_begin(logs=logs)
+
+        ds = torch.utils.data.TensorDataset(
+            torch.from_numpy(np.array(ds_h5).transpose((0, 3, 2, 1))),
+        )
+        dl = torch.utils.data.DataLoader(ds, batch_size=batchSize)
+        predictions = np.zeros((num_superpixels, bayesian_samples, num_classes))
+        catWeights = np.zeros((num_superpixels, bayesian_samples, num_classes))
         with torch.no_grad():
             model.eval()  # Tell torch that we will be doing predictions
-            predictions_raw = model(torch.from_numpy(ds))
-            predictions = predictions_raw.detach().cpu().numpy()
+            row: int = 0
+            for i, data in enumerate(dl):
+                for cb in callbacks:
+                    cb.on_predict_batch_begin(i)
+                inputs = data[0]
+                new_row = row + inputs.shape[0]
+                # print(f'inputs[{i}].shape = {inputs.shape}')
+                predictions_raw = model(inputs, bayesian_samples)
+                catWeights_raw = torch.nn.functional.softmax(predictions_raw, dim=-1)
+                predictions[row:new_row, :, :] = predictions_raw.detach().cpu().numpy()
+                # softmax to scale to 0 to 1.
+                catWeights[row:new_row, :, :] = catWeights_raw.detach().cpu().numpy()
+                row = new_row
+                for cb in callbacks:
+                    cb.on_predict_batch_end(i)
         for cb in callbacks:
             cb.on_predict_end({'outputs': predictions})
         prog.item_progress(item, 0.4)
         # scale to units
-        cats = [np.argmax(r) for r in predictions]
-        # softmax to scale to 0 to 1.
-        catWeights = torch.nn.functional.softmax(predictions, dim=1)
-        return cats, catWeights, predictions
+        return catWeights, predictions
 
     def loadModel(self, modelPath):
         model = torch.load(modelPath)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
   flake8-quotes
   ruff
 commands =
-  ruff superpixel_classification
+  ruff check superpixel_classification
   flake8 {posargs}
 
 [flake8]
@@ -66,4 +66,4 @@ commands =
   isort {posargs:.}
   autopep8 -ria superpixel_classification
   unify --in-place --recursive superpixel_classification
-  ruff superpixel_classification --fix
+  ruff check superpixel_classification --fix


### PR DESCRIPTION
Add `batchbald` to the list of supported certainty metrics, `confidence`, `margin`, and `negative_entropy`.  This pull request extends work begun in Pull Request #12 to a minimum viable product that works on basic cases.  (Future work can find and fix edge cases, possibly tweak high-level parameters so as to train with fewer labels, and possibly address any performance issues so as to run faster per label.)

This pull request also raises the Python version to 3.11 and restores the optional `torch` Python package dependency.

This code works on my computer, but ... reviewers / testing should test the new `batchbald` functionality to verify that it also works for you.  Also please test one or more of the previous certainty metrics to make sure that that code, which is tensorflow-based, is not broken by this new code that is torch-based.