### PR TITLE
Run CI periodically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,3 +48,15 @@ workflows:
             branches:
               only:
                 - main
+
+  periodic:
+    triggers:
+      - schedule:
+          # Run every 4th of the month at 3 a.m.
+          cron: "0 3 4 * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - build_docker


### PR DESCRIPTION
We should be notified of build issues in a more timely way if there are any changes.