### PR TITLE
Compute and use optimal batchsize

### DIFF
--- a/superpixel_classification/SuperpixelClassification/SuperpixelClassification.xml
+++ b/superpixel_classification/SuperpixelClassification/SuperpixelClassification.xml
@@ -105,8 +105,8 @@
       <longflag>batchsize</longflag>
       <label>Batch Size</label>
       <channel>input</channel>
-      <default>32</default>
-      <description>Training batch size</description>
+      <default>-1</default>
+      <description>Training batch size (-1 indicates optimal batch size)</description>
     </integer>
     <integer>
       <name>epochs</name>

--- a/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTensorflow.py
+++ b/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTensorflow.py
@@ -110,11 +110,11 @@ class SuperpixelClassificationTensorflow(SuperpixelClassificationBase):
         if not training and self.prediction_optimal_batchsize is not None:
             return self.prediction_optimal_batchsize
         # Find an optimal batch_size
-        maximum_batchSize: int = len(ds)
+        maximum_batchSize: int = 2 * len(ds) - 1
         batchSize: int = 2
         # We are using a value greater than 0.0 for add_seconds so that small imprecise
         # timings for small batch sizes don't accidentally trip the time check.
-        add_seconds: float = 0.5
+        add_seconds: float = 0.05
         previous_time: float = 1e100
         while batchSize <= maximum_batchSize:
             try:
@@ -134,7 +134,7 @@ class SuperpixelClassificationTensorflow(SuperpixelClassificationBase):
         batchSize //= 2
         return self.cacheOptimalBatchSize(batchSize, model, training)
 
-    def cacheOptimalBatchSize(self, batchSize: int, model: torch.nn.Module, training: bool) -> int:
+    def cacheOptimalBatchSize(self, batchSize, model, training) -> int:
         if training:
             self.training_optimal_batchsize = batchSize
         else:

--- a/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTorch.py
+++ b/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTorch.py
@@ -144,6 +144,11 @@ class SuperpixelClassificationTorch(SuperpixelClassificationBase):
         tempdir: str,
         trainingSplit: float,
     ):
+        # make model
+        num_classes: int = len(record['labels'])
+        model: torch.nn.Module = _BayesianTorchModel(num_classes)
+        model.to(model.device)
+
         # print(f'Torch trainModelDetails(batchSize={batchSize}, ...)')
         # Make a data set and a data loader for each of training and validation
         count: int = len(record['ds'])
@@ -167,17 +172,15 @@ class SuperpixelClassificationTorch(SuperpixelClassificationBase):
         val_arg2 = torch.from_numpy(record['labelds'][val_indices])
         train_ds = torch.utils.data.TensorDataset(train_arg1, train_arg2)
         val_ds = torch.utils.data.TensorDataset(val_arg1, val_arg2)
+        if batchSize < 1:
+            batchSize = self.findOptimalBatchSize(model, train_ds)
+            print(f'Optimal batch size for training (device = {model.device}) = {batchSize}')
         train_dl = torch.utils.data.DataLoader(train_ds, batch_size=batchSize)
         val_dl = torch.utils.data.DataLoader(val_ds, batch_size=batchSize)
         prog.progress(0.2)
 
-        # make model
-        num_classes: int = len(record['labels'])
-        model: torch.nn.Module = _BayesianTorchModel(num_classes)
-        model.to(model.device)
         prog.message('Training model')
         prog.progress(0)
-
         history = self.fitModel(
             model, train_dl, val_dl, epochs, callbacks=[_LogTorchProgress(prog, epochs)],
         )
@@ -300,7 +303,7 @@ class SuperpixelClassificationTorch(SuperpixelClassificationBase):
         return history
 
     def predictLabelsForItemDetails(
-            self, batchSize: int, ds_h5, item, model: torch.nn.Module, prog: ProgressHelper,
+        self, batchSize: int, ds_h5, item, model: torch.nn.Module, prog: ProgressHelper,
     ):
         # print(f'Torch predictLabelsForItemDetails(batchSize={batchSize}, ...)')
         num_superpixels: int = ds_h5.shape[0]
@@ -323,6 +326,9 @@ class SuperpixelClassificationTorch(SuperpixelClassificationBase):
         ds: torch.utils.data.TensorDataset = torch.utils.data.TensorDataset(
             torch.from_numpy(np.array(ds_h5).transpose((0, 3, 2, 1))),
         )
+        if batchSize < 1:
+            batchSize = self.findOptimalBatchSize(model, ds)
+            print(f'Optimal batch size for prediction (device = {model.device}) = {batchSize}')
         dl: torch.utils.data.DataLoader = torch.utils.data.DataLoader(ds, batch_size=batchSize)
         predictions: NDArray[np.float_] = np.zeros((num_superpixels, bayesian_samples, num_classes))
         catWeights: NDArray[np.float_] = np.zeros((num_superpixels, bayesian_samples, num_classes))
@@ -349,6 +355,30 @@ class SuperpixelClassificationTorch(SuperpixelClassificationBase):
         prog.item_progress(item, 0.4)
         # scale to units
         return catWeights, predictions
+
+    def findOptimalBatchSize(
+        self, model: torch.nn.Module, ds: torch.utils.data.TensorDataset,
+    ) -> int:
+        # Find an optimal batch_size
+        maximum_batchSize: int = 65536  # power of two
+        batchSize: int = 1
+        while batchSize < maximum_batchSize:
+            batchSize *= 2
+            try:
+                dl: torch.utils.data.DataLoader
+                dl = torch.utils.data.DataLoader(ds, batch_size=batchSize)
+                with torch.no_grad():
+                    model.eval()  # Tell torch that we will be doing predictions
+                    data: Sequence[torch.Tensor] = next(iter(dl))
+                    inputs: torch.Tensor = data[0]
+                    inputs = inputs.to(model.device)
+                    model(inputs, model.bayesian_samples)
+            except RuntimeError as e:
+                if 'out of memory' in str(e):
+                    return batchSize // 2
+                else:
+                    raise e
+        return batchSize
 
     def loadModel(self, modelPath):
         model = torch.load(modelPath)

--- a/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTorch.py
+++ b/superpixel_classification/SuperpixelClassification/SuperpixelClassificationTorch.py
@@ -369,11 +369,11 @@ class SuperpixelClassificationTorch(SuperpixelClassificationBase):
         if not training and self.prediction_optimal_batchsize is not None:
             return self.prediction_optimal_batchsize
         # Find an optimal batch_size
-        maximum_batchSize: int = ds.tensors[0].shape[0]
+        maximum_batchSize: int = 2 * ds.tensors[0].shape[0] - 1
         batchSize: int = 2
         # We are using a value greater than 0.0 for add_seconds so that small imprecise
         # timings for small batch sizes don't accidentally trip the time check.
-        add_seconds: float = 1.0
+        add_seconds: float = 0.05
         previous_time: float = 1e100
         while batchSize <= maximum_batchSize:
             try:


### PR DESCRIPTION
Closes Issue #22.

Whether tensorflow or torch, a supplied `args.batchSize` of -1 (or any other value less than 1) will be a request to optimize the batch size.  The result will be the largest power of two that doesn't cause an exception.  (Edit: we also introduce a timing metric.)

<strike>Note that this pull request is hardcoded to always optimize the batch size, and thus will optimize the batch size even though the code in the `wsi-superpixel-guided-labeling` repository is not yet updated to supply a value of -1 for `batchSize`.  This will enable testing of this pull request in isolation.</stike>  After testing, a subsequent commit (or separate pull request) can undo the hardcoded value of -1 for `batchSize`.