### PR TITLE
ENH: Support features of shape (1024,)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
 
 COPY . /opt/scw
 WORKDIR /opt/scw
-RUN python -m pip install --no-cache-dir -e .[tensorflow,torch] --find-links https://girder.github.io/large_image_wheels --extra-index-url https://download.pytorch.org/whl/cu117 && \
+RUN python -m pip install --no-cache-dir -e .[tensorflow,torch] --find-links https://girder.github.io/large_image_wheels --extra-index-url https://download.pytorch.org/whl/cu126 && \
     rm -rf /root/.cache/pip/* && \
     rdfind -minsize 32768 -makehardlinks true -makeresultsfile false /usr/local
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ tensorflow = [
     "keras",
 ]
 torch = [
-    "torch==1.13.1+cu117",
+    "torch",
+    "torchvision",
     "batchbald_redux",
+    "huggingface_hub",
+    "timm",
 ]

--- a/superpixel_classification/SuperpixelClassification/SuperpixelClassification.py
+++ b/superpixel_classification/SuperpixelClassification/SuperpixelClassification.py
@@ -1,8 +1,11 @@
 from histomicstk.cli.utils import CLIArgumentParser
+from SuperpixelClassificationBase import SuperpixelClassificationBase
 
 if __name__ == '__main__':
     args = CLIArgumentParser().parse_args()
-    if args.certainty == 'batchbald':
+    # Use tensorflow unless the dependency requires torch
+    superpixel_classification: SuperpixelClassificationBase
+    if args.certainty == 'batchbald' or args.feature == 'vector':
         from SuperpixelClassificationTorch import SuperpixelClassificationTorch
 
         superpixel_classification = SuperpixelClassificationTorch()

--- a/superpixel_classification/SuperpixelClassification/SuperpixelClassification.xml
+++ b/superpixel_classification/SuperpixelClassification/SuperpixelClassification.xml
@@ -163,6 +163,15 @@
       <element>negative_entropy</element>
       <element>batchbald</element>
     </string-enumeration>
+    <string-enumeration>
+      <name>feature</name>
+      <label>Feature Shape</label>
+      <description>Whether a feature is superpixel image data or a foundation model vector</description>
+      <longflag>feature</longflag>
+      <default>image</default>
+      <element>image</element>
+      <element>vector</element>
+    </string-enumeration>
   </parameters>
   <parameters advanced="true">
     <label>Girder API URL and Key</label>


### PR DESCRIPTION
ENH: Support an active learning model that consumes vector shape
ENH: Support non-Bayesian Torch models
ENH: Support both 2- and 3-dim Torch model() output.
ENH: Connect to and use hf-hub:MahmoodLab/UNI
ENH: Support (image or vector) feature creation in batches
ENH: Update version of Torch and dependencies to always current
ENH: Update to CUDA 12.6
DOC: Rename _BayesianTorchModel to _BayesianPatchTorchModel

This code supports the creation of vector-shaped feature vectors using `hf-hub:MahmoodLab/UNI`.  Regardless of how the feature vectors were created, this code supports the use of these feature vectors in training (linear probing) and prediction for active learning; supply `--feature vector` in the call to `SuperpixelClassification`.

To create feature vectors using `hub:MahmoodLab/UNI`, you will need permission to use UNI, including a HuggingFace token.   The building / composing of `DigitalSlideArchive/digital_slide_archive/devops/dsa` should include a `docker-compose.override.yml` file, which should include
```yml
services:
  worker:
    environment:
      GIRDER_WORKER_DOCKER_RUN_OPTIONS: '{"volumes": ["/wheretofindmy/.cache/huggingface:/root/.cache/huggingface:rw"]}'
```
... where `/wheretofindmy` is often your home directory.  (`docker-compose.override.yml` can also include other fields within `services:`, `worker:`, or `environment:`.  It can also mount a volume to gain access to a `provision.local.yaml` file.)  This gives the superpixel-classification code access to the HuggingFace token and UNI data needed to invoke UNI.

This code requires a version of `girder_worker` that incorporates Pull Request https://github.com/girder/girder_worker/pull/405, which has already been merged.  Also, this functionality will not be exposed to the user via the GUI until a subsequent pull request to `DigitalSlideArchive/wsi-superpixel-guided-labeling` has been merged.